### PR TITLE
Handle empty Items with unempty LastEvaluatedKey

### DIFF
--- a/lib/paginator.js
+++ b/lib/paginator.js
@@ -59,7 +59,11 @@
  * @returns {string | undefined}
  */
 const encodeCursor = (params, lastEvaluatedKey, result) => {
-  if (!lastEvaluatedKey && !params.back) {
+  if (
+    !result.Items
+    || !result.Items.length
+    || (!lastEvaluatedKey && !params.back)
+  ) {
     return undefined;
   }
 
@@ -126,7 +130,11 @@ const paginatorFunctionFactory = () => ({
       limit,
       cursor: encodeCursor(params, result.LastEvaluatedKey, result),
       backCursor: encodeBackCursor(params),
-      hasMoreData: params.back || result.LastEvaluatedKey !== undefined,
+      hasMoreData:
+        params.back
+        || (result.LastEvaluatedKey !== undefined
+          && result.Items
+          && result.Items.length > 0),
       count: result.Count,
     },
   }),

--- a/test/paginator.spec.js
+++ b/test/paginator.spec.js
@@ -23,6 +23,23 @@ describe('DynamoDB Paginator', () => {
         },
       );
     });
+    it('should handle empty Items and an unempty LastEvaluatedKey', () => {
+      const params = { TableName: 'Users' };
+      const result = { Items: [], Count: 0, LastEvaluatedKey: 'not empty' };
+      const limit = 25;
+
+      const paginatedResult = getPaginatedResult(params, limit, result);
+
+      expect(paginatedResult).toEqual({
+        data: [],
+        meta: {
+          limit,
+          cursor: undefined,
+          hasMoreData: false,
+          count: 0,
+        },
+      });
+    });
   });
 
   it('should return a paginated list with a single result', () => {


### PR DESCRIPTION
If you filter out all of the results you can end up with an empty `Items` list, but still have a `LastEvaluatedKey`. If so then the array access fails. This fixes that