### PR TITLE
feat: add support for search queries with a GSI/LSI index

### DIFF
--- a/lib/paginator.ts
+++ b/lib/paginator.ts
@@ -23,15 +23,23 @@ const encodeCursor = (
   }
 
   const referenceKey = lastEvaluatedKey || params.ExclusiveStartKey;
-  const [hashKey, sortKey] = Object.keys(referenceKey);
-  const firstKey = {
-    [hashKey]: referenceKey[hashKey],
-    [sortKey]: result.Items[0][sortKey],
-  };
-  const lastKey = {
-    [hashKey]: referenceKey[hashKey],
-    [sortKey]: result.Items[result.Items.length - 1][sortKey],
-  };
+  const keys = Object.keys(referenceKey);
+  const firstKey = keys.reduce((obj: Record<string, NativeAttributeValue>, key) => {
+    const newObj = { ...obj };
+    if (result.Items) {
+      newObj[key] = result.Items[0][key];
+    }
+    return newObj;
+  }, {});
+
+  const lastKey = keys.reduce((obj: Record<string, NativeAttributeValue>, key) => {
+    const newObj = { ...obj };
+    if (result.Items) {
+      newObj[key] = result.Items[result.Items.length - 1][key];
+    }
+    return newObj;
+  }, {});
+
   const startKey =
     !params.back || !params.backKey ? lastEvaluatedKey : firstKey;
 

--- a/test/paginator.spec.ts
+++ b/test/paginator.spec.ts
@@ -106,6 +106,37 @@ describe("DynamoDB Paginator", () => {
       });
     });
 
+      it("should return a paginated list which has more pages left when using a GSI to search", () => {
+          const params = { TableName: "Users" };
+          const result = {
+              Items: [
+                  { PK: 1, SK: "2024-01-02", GSI1PK: "a@aap.be", GSI1SK: "2024-01-02" },
+                  { PK: 2, SK: "2024-02-02", GSI1PK: "b@aap.be", GSI1SK: "2024-01-02" },
+              ],
+              Count: 2,
+              LastEvaluatedKey: { PK: 2, SK: "2024-02-02", GSI1PK: "b@aap.be", GSI1SK: "2024-01-02" },
+              $metadata: {},
+          };
+          const limit = 25;
+
+          const paginatedResult = getPaginatedResult(params, limit, result);
+
+          expect(paginatedResult).toEqual({
+              data: [
+                  { PK: 1, SK: "2024-01-02", GSI1PK: "a@aap.be", GSI1SK: "2024-01-02" },
+                  { PK: 2, SK: "2024-02-02", GSI1PK: "b@aap.be", GSI1SK: "2024-01-02" },
+              ],
+              meta: {
+                  limit,
+                  // eslint-disable-next-line max-len
+                  cursor:
+                      "eyJUYWJsZU5hbWUiOiJVc2VycyIsIkV4Y2x1c2l2ZVN0YXJ0S2V5Ijp7IlBLIjoyLCJTSyI6IjIwMjQtMDItMDIiLCJHU0kxUEsiOiJiQGFhcC5iZSIsIkdTSTFTSyI6IjIwMjQtMDEtMDIifSwicHJldmlvdXNLZXlzIjpbeyJQSyI6MiwiU0siOiIyMDI0LTAyLTAyIiwiR1NJMVBLIjoiYkBhYXAuYmUiLCJHU0kxU0siOiIyMDI0LTAxLTAyIn1dLCJiYWNrIjpmYWxzZX0=",
+                  hasMoreData: true,
+                  count: 2,
+              },
+          });
+      });
+
     it("should return a paginated list which has more pages left with a custom encoding function", () => {
       const params = { TableName: "Users" };
       const result = {

--- a/test/paginator.spec.ts
+++ b/test/paginator.spec.ts
@@ -107,7 +107,7 @@ describe("DynamoDB Paginator", () => {
     });
 
       it("should return a paginated list which has more pages left when using a GSI to search", () => {
-          const params = { TableName: "Users" };
+          const params = { TableName: "Users", IndexName: "GSI1" };
           const result = {
               Items: [
                   { PK: 1, SK: "2024-01-02", GSI1PK: "a@aap.be", GSI1SK: "2024-01-02" },
@@ -127,10 +127,11 @@ describe("DynamoDB Paginator", () => {
                   { PK: 2, SK: "2024-02-02", GSI1PK: "b@aap.be", GSI1SK: "2024-01-02" },
               ],
               meta: {
+                  backCursor: undefined,
                   limit,
                   // eslint-disable-next-line max-len
                   cursor:
-                      "eyJUYWJsZU5hbWUiOiJVc2VycyIsIkV4Y2x1c2l2ZVN0YXJ0S2V5Ijp7IlBLIjoyLCJTSyI6IjIwMjQtMDItMDIiLCJHU0kxUEsiOiJiQGFhcC5iZSIsIkdTSTFTSyI6IjIwMjQtMDEtMDIifSwicHJldmlvdXNLZXlzIjpbeyJQSyI6MiwiU0siOiIyMDI0LTAyLTAyIiwiR1NJMVBLIjoiYkBhYXAuYmUiLCJHU0kxU0siOiIyMDI0LTAxLTAyIn1dLCJiYWNrIjpmYWxzZX0=",
+                      "eyJUYWJsZU5hbWUiOiJVc2VycyIsIkluZGV4TmFtZSI6IkdTSTEiLCJFeGNsdXNpdmVTdGFydEtleSI6eyJQSyI6MiwiU0siOiIyMDI0LTAyLTAyIiwiR1NJMVBLIjoiYkBhYXAuYmUiLCJHU0kxU0siOiIyMDI0LTAxLTAyIn0sInByZXZpb3VzS2V5cyI6W3siUEsiOjIsIlNLIjoiMjAyNC0wMi0wMiIsIkdTSTFQSyI6ImJAYWFwLmJlIiwiR1NJMVNLIjoiMjAyNC0wMS0wMiJ9XSwiYmFjayI6ZmFsc2V9",
                   hasMoreData: true,
                   count: 2,
               },


### PR DESCRIPTION
This PR adds support for pagination when searching with a GSI/LSI index. 
The lastEvaluated key contains the following depending on the kind of query you perform:

- a normal search only the primary partition key and primary sort key are part of the lastEvaluated key.
- a query on GSI, then the LastEvaluatedKey will be the compose of GSI partition key, GSI sort key, primary partition key and primary sort key.
- a query on LSI, then the LastEvaluatedKey will be the compose of LSI sort key, primary partition key and primary sort key.
